### PR TITLE
Fix broken GoogleSQL Toolkit link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ Some other documentation:
 *   [GoogleSQL Resolved AST](docs/resolved_ast.md), documenting the intermediate
     representation produced by the GoogleSQL analyzer.
 *   [GoogleSQL
-    Toolkit](https://github.com/GoogleCloudPlatform/googlesql-toolkit), a
-    project using GoogleSQL to analyze and understand queries against BigQuery,
-    and other GoogleSQL engines.
+    Toolkit], GoogleSQL Toolkit, a project using GoogleSQL to analyze and understand queries against BigQuery and other GoogleSQL engines.
 *   Pipe query syntax
     *   See the [reference documentation](https://github.com/google/googlesql/blob/master/docs/pipe-syntax.md)
         and [research paper](https://research.google/pubs/pub1005959/).


### PR DESCRIPTION
## Fix #166 
Removed broken link to GoogleSQL Toolkit from README.

## Reason
The referenced repository appears to be unavailable or not publicly accessible, resulting in a broken link.

## Changes
- Removed hyperlink
- Retained text for context