### PR TITLE
Migrate remaining native rules for Bazel 9

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,9 @@
 # environments.
 # This is a special snowflake setting that bazel requires special handling for.
 
+# Load C++ and proto rules for third-party BUILD files on Bazel 9.
+build --incompatible_autoload_externally=+cc_binary,+cc_library,+cc_test,+cc_proto_library,+java_proto_library,+proto_library
+
 # By default, we don't suppress any warnings, to get clang-specific warning
 # suppression you can invoke with --config=clang
 build:clang --action_env=BAZEL_CXXOPTS="-std=c++20"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -76,6 +76,7 @@ bazel_dep(name = "rules_jvm_external", version = "6.8")
 bazel_dep(name = "rules_m4", version = "0.3")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_python", version = "1.6.1")
+bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "toolchains_llvm", version = "1.5.0")
 
 # Java dependencies.

--- a/bazel/farmhash.BUILD
+++ b/bazel/farmhash.BUILD
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 licenses(["notice"])  # Apache v2.0
 
 cc_library(

--- a/bazel/http_archive_deps.bzl
+++ b/bazel/http_archive_deps.bzl
@@ -68,7 +68,7 @@ def _http_archive_deps_impl(_):
 
     http_archive(
         name = "native_utils",
-        build_file_content = "licenses([\"notice\"]) # MIT\njava_library(\nname = \"native_utils\",\nvisibility = [\"//visibility:public\"],\nsrcs = glob([\"src/main/java/cz/adamh/utils/*.java\"]),\n)",
+        build_file_content = "load(\"@rules_java//java:java_library.bzl\", \"java_library\")\n\nlicenses([\"notice\"]) # MIT\njava_library(\nname = \"native_utils\",\nvisibility = [\"//visibility:public\"],\nsrcs = glob([\"src/main/java/cz/adamh/utils/*.java\"]),\n)",
         sha256 = "6013c0988ba40600e238e47088580fd562dcecd4afd3fcf26130efe7cb1620de",
         strip_prefix = "native-utils-e6a39489662846a77504634b6fafa4995ede3b1d",
         url = "https://github.com/adamheinrich/native-utils/archive/e6a39489662846a77504634b6fafa4995ede3b1d.tar.gz",

--- a/bazel/icu.BUILD
+++ b/bazel/icu.BUILD
@@ -17,6 +17,7 @@
 Rules for adding './configure && make' style dependencies.
 """
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
 licenses(["notice"])  # Apache v2.0

--- a/examples/bazel/.bazelrc
+++ b/examples/bazel/.bazelrc
@@ -17,3 +17,6 @@
 # GoogleSQL requires c++20 support to match internal Google development
 # environments.
 build --cxxopt="-std=c++20"
+
+# Load C++ and proto rules for third-party BUILD files on Bazel 9.
+build --incompatible_autoload_externally=+cc_binary,+cc_library,+cc_test,+cc_proto_library,+java_proto_library,+proto_library

--- a/examples/bazel/BUILD.bazel
+++ b/examples/bazel/BUILD.bazel
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])

--- a/examples/bazel/MODULE.bazel
+++ b/examples/bazel/MODULE.bazel
@@ -26,6 +26,7 @@ local_path_override(
 
 bazel_dep(name = "abseil-cpp", version = "20250814.1", repo_name = "absl")
 bazel_dep(name = "googletest", version = "1.17.0")
+bazel_dep(name = "rules_cc", version = "0.2.14")
 
 # Dev dependency.
 bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)

--- a/googlesql/common/BUILD
+++ b/googlesql/common/BUILD
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load(":builddefs.bzl", "gen_module_test")
 

--- a/googlesql/parser/BUILD
+++ b/googlesql/parser/BUILD
@@ -16,6 +16,8 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")

--- a/googlesql/tools/execute_query/BUILD
+++ b/googlesql/tools/execute_query/BUILD
@@ -18,6 +18,7 @@ load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//googlesql/tools/execute_query:build_rules.bzl", "execute_query_test")
 
 package(
@@ -645,4 +646,5 @@ execute_query_test(
 bzl_library(
     name = "build_rules_bzl",
     srcs = ["build_rules.bzl"],
+    deps = ["@rules_shell//shell:rules_bzl"],
 )

--- a/googlesql/tools/execute_query/build_rules.bzl
+++ b/googlesql/tools/execute_query/build_rules.bzl
@@ -21,12 +21,14 @@ This just runs the script and validates that it succeeds, without checking
 query output.
 """
 
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 def execute_query_test(
         name,
         sql_file,
         args = [],
         **kwargs):
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = ["//googlesql/tools/execute_query:run_execute_query_test.sh"],
         args = [

--- a/googlesql/tools/execute_query/web/BUILD
+++ b/googlesql/tools/execute_query/web/BUILD
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(":embed_files.bzl", "gen_string_constant_header_file")
 
 package(default_visibility = ["//googlesql/base:googlesql_implementation"])


### PR DESCRIPTION
Adapt [cloud-spanner-emulator#374](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/pull/374) to GoogleSQL: explicitly load the remaining C++, Java, proto, and shell rules in GoogleSQL-owned BUILD files, BUILD overlays, and `execute_query_test`; declare the required module dependencies; and add the temporary autoload fallback for unchanged third-party BUILD files. Include the separate Bazel example and keep the pinned Bazel 7.6.1 version. GoogleSQL uses Textmapper, so the emulator's JavaCC changes are not included.

Validation: package-loading queries pass for GoogleSQL and its example under Bazel 7.6.1, and for a separate Bazel 9.0.0 consumer with a test-only `rules_swift` 3.1.2 override. Ordinary Bazel 9 resolution is blocked by the existing gRPC/Bazel `rules_swift` compatibility-level mismatch; the override is not included in this PR. Compilation and runtime tests were not run.

Tracking issue: [#177](https://github.com/google/googlesql/issues/177).

GoogleSQL's [contribution guide](https://github.com/google/googlesql/blob/master/CONTRIBUTING.md) asks for issues rather than external code contributions. This draft provides the proposed implementation for maintainers to incorporate internally. Consuming root modules do not inherit GoogleSQL's `.bazelrc` and may still need the third-party autoload flag.

-zbarskybot
