### PR TITLE
Keep the LLVM development dependency root-only

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -76,7 +76,8 @@ bazel_dep(name = "rules_jvm_external", version = "6.8")
 bazel_dep(name = "rules_m4", version = "0.3")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_python", version = "1.6.1")
-bazel_dep(name = "toolchains_llvm", version = "1.5.0")
+
+bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
 
 # Java dependencies.
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")


### PR DESCRIPTION
Apply the root-only development-dependency principle from [cloud-spanner-emulator#376](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/pull/376) to GoogleSQL. Mark `toolchains_llvm` as a development dependency, matching its already-development-only module extension and toolchain registration and the declaration in `examples/bazel/MODULE.bazel`. This removes GoogleSQL's unnecessary `toolchains_llvm` module requirement from consuming modules without changing GoogleSQL's root development toolchain or its production dependencies.

Validation: Bazel 7.6.1 repository-mapping checks confirm `toolchains_llvm` disappears when GoogleSQL is consumed and remains available when GoogleSQL is the root; buildifier and `git diff --check` pass. Full `mod graph` inspection is blocked by an existing `envoy_api`/`googleapis` extension mismatch.

Tracking issue: [#179](https://github.com/google/googlesql/issues/179).

GoogleSQL's [contribution guide](https://github.com/google/googlesql/blob/master/CONTRIBUTING.md) asks for issues rather than external code contributions. This draft provides the proposed implementation for maintainers to incorporate internally.

-zbarskybot
